### PR TITLE
Bug#24 fix: Added stdin_open=true to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
   front-end:
     image: gitinsights:v001
     command: yarn dev:client
+    stdin_open: true
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This ensures that frontend starts from Docker as expected. Verified
with a fresh docker-compose on local machine.

Fix for #24 

Please let me know if I've to commit my yarn.lock file as well.